### PR TITLE
Use the C++ steady_clock on Mac OSX, rather than using the Mach kernel clock service

### DIFF
--- a/env/env_posix.cc
+++ b/env/env_posix.cc
@@ -726,7 +726,7 @@ class PosixEnv : public Env {
     return static_cast<uint64_t>(ts.tv_sec) * 1000000000 + ts.tv_nsec;
 #elif defined(OS_SOLARIS)
     return gethrtime();
-#elif defined(__MACH__)
+#elif defined(__MACH__) && !defined(__APPLE__)
     clock_serv_t cclock;
     mach_timespec_t ts;
     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);


### PR DESCRIPTION
This is approximately 80x faster.