### PR TITLE
Bazel WORKSPACE and BUILD file tweaks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,0 @@
-build --crosstool_top=@toolchain//cpp:toolchain

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,11 +14,11 @@ http_archive(
     strip_prefix = "snappy-add_bazel",
 )
 
-new_http_archive(
+http_archive(
     name = "org_lz4",
     urls = ["https://github.com/lz4/lz4/archive/v1.8.2.zip"],
     strip_prefix = "lz4-1.8.2",
-    build_file = "third_party/lz4/BUILD.external",
+    build_file = "@//third_party/lz4:BUILD.external",
     sha256 = "6df2bc7b830d4a23ca6f0a19a772fc0a61100f98baa843f9bbf873a80b6840d5",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,12 +25,7 @@ new_http_archive(
 http_archive(
     name = "toolchain",
     urls = [
-        # The file: URL is useful for testing the build, but is not generally necessary since Bazel handles caching
-        # external dependencies.
-        # TODO(james): Remove this URL when the Bazel build is stable.
-        # "file:///home/james/git/toolchain-master.tgz",
-        "https://github.com/stardog-union/toolchain/archive/master.zip",
+        "https://github.com/stardog-union/toolchain/archive/v3.zip",
     ],
-    strip_prefix = "toolchain-master",
-    sha256 = "d0740cacb99833911baba82041bb4429f9d3182522fe0fd4c131335ac8343891",
+    strip_prefix = "toolchain-3",
 )

--- a/third_party/gtest/BUILD
+++ b/third_party/gtest/BUILD
@@ -8,12 +8,30 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 
+cc_library(
+    name = "gtest_main",
+    deps = [
+        "@com_google_googletest//:gtest_main",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 cc_test(
-    name = "compile_test",
+    name = "gtest_compile_test",
     srcs = [
         "compile_test.cpp",
     ],
     deps = [
         ":gtest",
+    ],
+)
+
+cc_test(
+    name = "gtest_main_compile_test",
+    srcs = [
+        "gtest_main_compile_test.cpp",
+    ],
+    deps = [
+        ":gtest_main",
     ],
 )

--- a/third_party/gtest/gtest_main_compile_test.cpp
+++ b/third_party/gtest/gtest_main_compile_test.cpp
@@ -1,0 +1,9 @@
+#include "gtest/gtest.h"
+
+namespace stardog {
+  namespace {
+    TEST(CompileTest, Compiles) {
+      EXPECT_TRUE(true);
+    }
+  }
+}

--- a/third_party/lz4/BUILD
+++ b/third_party/lz4/BUILD
@@ -13,6 +13,6 @@ cc_test(
     ],
     deps = [
         ":lz4",
-	"//third_party/gtest",
+	"//third_party/gtest:gtest_main",
     ],
 )

--- a/third_party/snappy/BUILD
+++ b/third_party/snappy/BUILD
@@ -13,7 +13,7 @@ cc_test(
     ],
     deps = [
         ":snappy",
-	"//third_party/gtest",
+	"//third_party/gtest:gtest_main",
     ],
 )
 


### PR DESCRIPTION
None of these changes affect the build of stardog.

Bring in current version of the toolchain by default.
Add a gtest rule to link in gtest's `main()` function.
Fix the WORKSPACE reference to lz4's BUILD file.
Make lz4's `compile_test` pass.

After merging this PR with `stardog_changes`, I will also cherry-pick the commits onto the 5.18.3.1 branch.