### PR TITLE
Populate cf_id member of CompactionJobInfo for OnCompactionBegin

### DIFF
--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -1057,6 +1057,7 @@ void DBImpl::NotifyOnCompactionBegin(ColumnFamilyData* cfd,
   TEST_SYNC_POINT("DBImpl::NotifyOnCompactionBegin::UnlockMutex");
   {
     CompactionJobInfo info;
+    info.cf_id = cfd->GetID();
     info.cf_name = cfd->GetName();
     info.status = st;
     info.thread_id = env_->GetThreadID();


### PR DESCRIPTION
Looks like somebody simply missed initializing a member variable.  The column family ID, cf_id, is not set during OnCompactionBegin.  But it is set properly in the next function for OnCompactionCompleted.  Need this cf_id for tracking progress of a Stardog optimize since there may be multiple compactions required for a given column family.

I have put in a query to Facebook.  Anticipate filing a PR there too since the line is still missing in the most current code.