### PR TITLE
Raise default skiplist height from 12 to 17.

### DIFF
--- a/memtable/inlineskiplist.h
+++ b/memtable/inlineskiplist.h
@@ -72,7 +72,7 @@ class InlineSkipList {
   // in the allocator must remain allocated for the lifetime of the
   // skiplist object.
   explicit InlineSkipList(Comparator cmp, Allocator* allocator,
-                          int32_t max_height = 12,
+                          int32_t max_height = 17,
                           int32_t branching_factor = 4);
 
   // Allocates a key and a skip-list node, returning a pointer to the key

--- a/memtable/skiplist.h
+++ b/memtable/skiplist.h
@@ -50,7 +50,7 @@ class SkipList {
   // and will allocate memory using "*allocator".  Objects allocated in the
   // allocator must remain allocated for the lifetime of the skiplist object.
   explicit SkipList(Comparator cmp, Allocator* allocator,
-                    int32_t max_height = 12, int32_t branching_factor = 4);
+                    int32_t max_height = 17, int32_t branching_factor = 4);
 
   // Insert key into the list.
   // REQUIRES: nothing that compares equal to key is currently in the list.


### PR DESCRIPTION
Default skiplist height in rocksdb is same as original leveldb which had 4M write buffers.  Raising to 17 to match Basho.  Have seen consistent 5% improvement in bsbm100m create.

Paper on skip list is here:  https://dl.acm.org/doi/pdf/10.1145/78973.78977

The paper discusses MaxLevel which is same has height in rocksdb/leveldb code:

"Determining MaxLevel
Since we can safely cap levels at L(n), we should
choose MaxLevel = L(N) (where N is an upper bound on the number of elements in a skip list). If p = 1/2, using MaxLevel = 16 is appropriate for data structures con- taining up to 2^16 elements."

Our write buffers can often hold more than 2^17 items.  I tested with height of 25 and saw little to no performance gain.  Therefore sticking with 17 since it is a known improvement elsewhere and in quick Stardog test.  Will return to this later when there is time for greater experimentation and/or creating a way to control the height at runtime.