### PR TITLE
Bug fix:  missed a couple of things in recent encryption back port  

### DIFF
--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -485,6 +485,18 @@ EOF
             PLATFORM_CXXFLAGS="$PLATFORM_CXXFLAGS -faligned-new -DHAVE_ALIGNED_NEW"
         fi
     fi
+
+        if ! test $ROCKSDB_DISABLE_OPENSSL; then
+        # Test whether openssl is available
+        $CXX $CFLAGS -x c++ - -o /dev/null 2>/dev/null  <<EOF
+          #include <openssl/evp.h>
+          int main() {}
+EOF
+        if [ "$?" = 0 ]; then
+            COMMON_FLAGS="$COMMON_FLAGS -DROCKSDB_OPENSSL_AES_CTR"
+            PLATFORM_LDFLAGS="$PLATFORM_LDFLAGS -ldl"
+        fi
+    fi
 fi
 
 # TODO(tec): Fix -Wshorten-64-to-32 errors on FreeBSD and enable the warning.

--- a/env/env_encrypt2.cc
+++ b/env/env_encrypt2.cc
@@ -252,7 +252,7 @@ Status EncryptedEnv2::NewSequentialFile(const std::string& fname,
     if (status.ok()) {
       if (provider) {
         (*result) = std::unique_ptr<SequentialFile>(
-            new EncryptedSequentialFile(underlying.release(), stream.release(),
+            new EncryptedSequentialFile(std::move(underlying), std::move(stream),
                                         provider->GetPrefixLength()));
 
       } else {
@@ -290,7 +290,7 @@ Status EncryptedEnv2::NewRandomAccessFile(
       if (provider) {
         (*result) =
             std::unique_ptr<RandomAccessFile>(new EncryptedRandomAccessFile(
-                underlying.release(), stream.release(),
+                std::move(underlying), std::move(stream),
                 provider->GetPrefixLength()));
 
       } else {
@@ -322,7 +322,7 @@ Status EncryptedEnv2::NewWritableFile(const std::string& fname,
 
         if (status.ok()) {
           (*result) = std::unique_ptr<WritableFile>(new EncryptedWritableFile(
-              underlying.release(), stream.release(),
+              std::move(underlying), std::move(stream),
               encrypt_write_.second->GetPrefixLength()));
         }
       } else {
@@ -362,7 +362,7 @@ Status EncryptedEnv2::ReopenWritableFile(const std::string& fname,
 
         if (status.ok()) {
           (*result) = std::unique_ptr<WritableFile>(new EncryptedWritableFile(
-              underlying.release(), stream.release(),
+              std::move(underlying), std::move(stream),
               encrypt_write_.second->GetPrefixLength()));
         }
       } else {
@@ -398,7 +398,7 @@ Status EncryptedEnv2::ReuseWritableFile(const std::string& fname,
 
         if (status.ok()) {
           (*result) = std::unique_ptr<WritableFile>(new EncryptedWritableFile(
-              underlying.release(), stream.release(),
+              std::move(underlying), std::move(stream),
               encrypt_write_.second->GetPrefixLength()));
         }
       } else {
@@ -452,7 +452,7 @@ Status EncryptedEnv2::NewRandomRWFile(const std::string& fname,
       if (status.ok()) {
         if (provider) {
           (*result) = std::unique_ptr<RandomRWFile>(
-              new EncryptedRandomRWFile(underlying.release(), stream.release(),
+              new EncryptedRandomRWFile(std::move(underlying), std::move(stream),
                                         provider->GetPrefixLength()));
         } else {
           (*result).reset(underlying.release());

--- a/util/library_loader.cc
+++ b/util/library_loader.cc
@@ -3,9 +3,15 @@
 //  COPYING file in the root directory) and Apache 2.0 License
 //  (found in the LICENSE.Apache file in the root directory).
 
+#ifdef ROCKSDB_OPENSSL_AES_CTR
+#ifndef ROCKSDB_LITE
+
 #include "util/library_loader.h"
 
 #include <dlfcn.h>
+#include <stdio.h>
+
+#include "rocksdb/status.h"
 
 // link with -ldl
 
@@ -16,7 +22,7 @@ namespace rocksdb {
 #else
     const char * UnixLibCrypto::crypto_lib_name_ = "libcrypto.so";
 #endif
-    
+
 UnixLibraryLoader::UnixLibraryLoader(const char * library_name)
     : dl_handle_(nullptr) {
 
@@ -112,3 +118,6 @@ UnixLibCrypto::UnixLibCrypto()
 }
 
 } // namespace rocksdb
+
+#endif  // ROCKSDB_LITE
+#endif  // ROCKSDB_OPENSSL_AES_CTR

--- a/util/library_loader.h
+++ b/util/library_loader.h
@@ -5,9 +5,16 @@
 
 #pragma once
 
-#include <map>
-#include <string>
+#ifdef ROCKSDB_OPENSSL_AES_CTR
+#ifndef ROCKSDB_LITE
+
 #include <openssl/evp.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "rocksdb/env.h"
 
 namespace rocksdb {
 
@@ -127,7 +134,7 @@ public:
   }
 
   static const char * crypto_lib_name_;
-  
+
 protected:
   std::map<std::string, void *> functions_ {
     {"EVP_MD_CTX_new", nullptr}, {"EVP_MD_CTX_create", nullptr},
@@ -167,3 +174,5 @@ protected:
 };
 
 }  // namespace rocksdb
+#endif  // ROCKSDB_LITE
+#endif  // ROCKSDB_OPENSSL_AES_CTR

--- a/util/library_loader_test.cc
+++ b/util/library_loader_test.cc
@@ -5,6 +5,9 @@
 
 #include <gtest/gtest.h>
 
+#ifdef ROCKSDB_OPENSSL_AES_CTR
+#ifndef ROCKSDB_LITE
+
 #include "util/library_loader.h"
 
 namespace rocksdb {
@@ -18,7 +21,7 @@ namespace rocksdb {
     static const char * LIB_BAD_NAME = "libbubbagump.so";
     static const char * LIB_SSL_NAME = "libssl.so";
 #endif
-    
+
 
 class UnixLibraryLoaderTest {};
 
@@ -78,8 +81,10 @@ TEST(UnixLibraryLoaderTest, Crypto) {
 
 }
 
-
 }  // namespace rocksdb
+
+#endif  // ROCKSDB_LITE
+#endif  // ROCKSDB_OPENSSL_AES_CTR
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
previous PR missed:

- ifdefs within library_loader files.  caused Windows build to fail both at Facebook and existing Stardog files
- switch to unique_ptr in env_encryption declarations

Unrelated:  added change to build_detect_platform that only benefits developer builds of rocksdb, i.e. Alex and me.  Automatically switches encryption code build on and off depending upon environment.  This is 100% isolated from Stardog bagel build.