### PR TITLE
make SetKeys public since now rwlock protected

### DIFF
--- a/include/rocksdb/env_encrypt2.h
+++ b/include/rocksdb/env_encrypt2.h
@@ -245,6 +245,8 @@ class EncryptedEnvV2 : public EnvWrapper {
 
   EncryptedEnvV2(Env* base_env, ReadKeys encrypt_read, WriteKey encrypt_write);
 
+  void SetKeys(ReadKeys encrypt_read, WriteKey encrypt_write);
+
   bool IsWriteEncrypted() const;
 
   // NewSequentialFile opens a file for sequential reading.
@@ -313,10 +315,6 @@ class EncryptedEnvV2 : public EnvWrapper {
 
  protected:
   void init();
-
-  // following is not thread safe, intended for constuction
-  //  and unit test only
-  void SetKeys(ReadKeys encrypt_read, WriteKey encrypt_write);
 
   template <class TypeFile>
   Status ReadSeqEncryptionPrefix(


### PR DESCRIPTION
Original SetKeys implementation was NOT thread safe.  Since then Facebook requested the change, and now thread safe.  Making the function public in our tree so protected_files.cpp can call it.