### PR TITLE
make mutex mutable for const function

### DIFF
--- a/util/channel.h
+++ b/util/channel.h
@@ -60,7 +60,7 @@ class channel {
 
  private:
   std::condition_variable cv_;
-  std::mutex lock_;
+  mutable std::mutex lock_;
   std::queue<T> buffer_;
   bool eof_;
 };


### PR DESCRIPTION
I confirm facebook/rocksdb has made this same change.  The size_t function is const.  It was trying to use lock_ and a recent compiler update spit that out as "bad".  Must make the lock mutable so it can change state in a const function