### PR TITLE
Bugfix:  Let buffer_size_ in WriteBufferManager be dynamically changed

### DIFF
--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -83,8 +83,12 @@ class WriteBufferManager {
     }
   }
 
+  void SetBufferSize(size_t new_size) {
+    buffer_size_ = new_size;
+  }
+
  private:
-  const size_t buffer_size_;
+  std::atomic<size_t> buffer_size_;
   const size_t mutable_limit_;
   std::atomic<size_t> memory_used_;
   // Memory that hasn't been scheduled to free.


### PR DESCRIPTION
Existing Facebook code sets WriteBufferManager's buffer_size_ parameters once at database start up.  The system might need to lower that value as column families and/or .sst files begin to chew up RAM.  The start up value comes from db_write_buffer_size.

This modification allows an informed user to pass an application created WriteBufferManager within DBOptions and subsequently change its internal buffer_size_ as needed.