### PR TITLE
block timing routines that slow performance and cannot be disabled vi…

### DIFF
--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -379,13 +379,17 @@ void StatisticsImpl::recordTick(uint32_t tickerType, uint64_t count) {
 void StatisticsImpl::measureTime(uint32_t histogramType, uint64_t value) {
   assert(enable_internal_stats_ ? histogramType < INTERNAL_HISTOGRAM_ENUM_MAX
                                 : histogramType < HISTOGRAM_ENUM_MAX);
-
+#if 0
   if (histogramType < HISTOGRAM_ENUM_MAX || enable_internal_stats_) {
     getThreadHistogramInfo(histogramType)->value.Add(value);
   }
   if (stats_ && histogramType < HISTOGRAM_ENUM_MAX) {
     stats_->measureTime(histogramType, value);
   }
+#else
+  (void)histogramType;
+  (void)value;
+#endif
 }
 
 Status StatisticsImpl::Reset() {

--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -94,7 +94,7 @@ class StopWatchNano {
   void Start() { start_ = env_->NowNanos(); }
 
   uint64_t ElapsedNanos(bool reset = false) {
-    auto now = env_->NowNanos();
+    auto now = 0; // env_->NowNanos();
     auto elapsed = now - start_;
     if (reset) {
       start_ = now;
@@ -103,7 +103,7 @@ class StopWatchNano {
   }
 
   uint64_t ElapsedNanosSafe(bool reset = false) {
-    return (env_ != nullptr) ? ElapsedNanos(reset) : 0U;
+    return 0; //(env_ != nullptr) ? ElapsedNanos(reset) : 0U;
   }
 
  private:

--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -91,7 +91,7 @@ class StopWatchNano {
     }
   }
 
-  void Start() { start_ = env_->NowNanos(); }
+  void Start() { start_ = 0; /*env_->NowNanos();*/ }
 
   uint64_t ElapsedNanos(bool reset = false) {
     auto now = 0; // env_->NowNanos();


### PR DESCRIPTION
This PR has two changes relating to statistics (the second being the most significant):

1. we use rocksdb 5.18 currently.  The latest release from Facebook allows users to selectively deactivate histograms while supporting other statistics.  5.18 does not.  Manually disabled the histogram code, but left it with "#if 0" block to help remember to do right thing once we upgrade our version.

2. The StopwatchNano object is currently used only within merge_helper.cc.  It is mostly, but not entirely, deactivated when user does not supply a statistics object.  The "not entirely" implies it is getting called once for every key passed to our ternary compaction filter.  The call to clock_gettime() within StopwatchNano is a significant overhead.  Completely killing it for now.

I will put together a patch to Facebook's rocksdb to properly fix merge_helper.cc.  That way the hack in #2 will go away naturally when we upgrade.  Hack #1 is going to require disabling the histograms when we create the statistics object within rocksconfig.cpp once we upgrade rocksdb.

Fix number 2 is known to increase "optimize" throughput per Jenkins starbench.