### PR TITLE
Bugfix::Proper merge helper fix (reverts kludge code)

### DIFF
--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -394,7 +394,9 @@ CompactionFilter::Decision MergeHelper::FilterMerge(const Slice& user_key,
                                                        kValueTypeForSeek);
     }
   }
-  total_filter_time_ += filter_timer_.ElapsedNanosSafe();
+  if (ShouldReportDetailedTime(env_, stats_)) {
+    total_filter_time_ += filter_timer_.ElapsedNanosSafe();
+  }
   return ret;
 }
 

--- a/db/merge_test.cc
+++ b/db/merge_test.cc
@@ -76,6 +76,24 @@ class CountMergeOperator : public AssociativeMergeOperator {
   std::shared_ptr<MergeOperator> mergeOperator_;
 };
 
+class EnvMergeTest : public EnvWrapper {
+ public:
+  EnvMergeTest() : EnvWrapper(Env::Default()) {}
+  //  ~EnvMergeTest() override {}
+
+  uint64_t NowNanos() override { ++now_nanos_count_; return target()->NowNanos(); }
+
+  static uint64_t now_nanos_count_;
+
+  static std::unique_ptr<EnvMergeTest> singleton_;
+
+  static EnvMergeTest * GetInstance() {if (nullptr == singleton_) singleton_.reset(new EnvMergeTest); return singleton_.get();}
+};
+
+uint64_t EnvMergeTest::now_nanos_count_ {0};
+std::unique_ptr<EnvMergeTest> EnvMergeTest::singleton_;
+
+
 std::shared_ptr<DB> OpenDb(const std::string& dbname, const bool ttl = false,
                            const size_t max_successive_merges = 0) {
   DB* db;
@@ -83,7 +101,9 @@ std::shared_ptr<DB> OpenDb(const std::string& dbname, const bool ttl = false,
   options.create_if_missing = true;
   options.merge_operator = std::make_shared<CountMergeOperator>();
   options.max_successive_merges = max_successive_merges;
-  Status s;
+  options.env = EnvMergeTest::GetInstance();
+
+ Status s;
   DestroyDB(dbname, Options());
 // DBWithTTL is not supported in ROCKSDB_LITE
 #ifndef ROCKSDB_LITE
@@ -360,6 +380,7 @@ void testPartialMerge(Counters* counters, DB* db, size_t max_merge,
   db->CompactRange(CompactRangeOptions(), nullptr, nullptr);
   ASSERT_EQ(tmp_sum, counters->assert_get("c"));
   ASSERT_EQ(num_partial_merge_calls, 0U);
+  ASSERT_EQ(EnvMergeTest::now_nanos_count_, 0U);
 }
 
 void testSingleBatchSuccessiveMerge(DB* db, size_t max_num_merges,

--- a/monitoring/statistics.cc
+++ b/monitoring/statistics.cc
@@ -379,13 +379,17 @@ void StatisticsImpl::recordTick(uint32_t tickerType, uint64_t count) {
 void StatisticsImpl::measureTime(uint32_t histogramType, uint64_t value) {
   assert(enable_internal_stats_ ? histogramType < INTERNAL_HISTOGRAM_ENUM_MAX
                                 : histogramType < HISTOGRAM_ENUM_MAX);
-
+#if 0
   if (histogramType < HISTOGRAM_ENUM_MAX || enable_internal_stats_) {
     getThreadHistogramInfo(histogramType)->value.Add(value);
   }
   if (stats_ && histogramType < HISTOGRAM_ENUM_MAX) {
     stats_->measureTime(histogramType, value);
   }
+#else
+  (void)histogramType;
+  (void)value;
+#endif
 }
 
 Status StatisticsImpl::Reset() {

--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -94,7 +94,7 @@ class StopWatchNano {
   void Start() { start_ = env_->NowNanos(); }
 
   uint64_t ElapsedNanos(bool reset = false) {
-    auto now = 0; // env_->NowNanos();
+    auto now = env_->NowNanos();
     auto elapsed = now - start_;
     if (reset) {
       start_ = now;
@@ -103,7 +103,7 @@ class StopWatchNano {
   }
 
   uint64_t ElapsedNanosSafe(bool reset = false) {
-    return 0; //(env_ != nullptr) ? ElapsedNanos(reset) : 0U;
+    return (env_ != nullptr) ? ElapsedNanos(reset) : 0U;
   }
 
  private:

--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -94,7 +94,7 @@ class StopWatchNano {
   void Start() { start_ = env_->NowNanos(); }
 
   uint64_t ElapsedNanos(bool reset = false) {
-    auto now = env_->NowNanos();
+    auto now = 0; // env_->NowNanos();
     auto elapsed = now - start_;
     if (reset) {
       start_ = now;
@@ -103,7 +103,7 @@ class StopWatchNano {
   }
 
   uint64_t ElapsedNanosSafe(bool reset = false) {
-    return (env_ != nullptr) ? ElapsedNanos(reset) : 0U;
+    return 0; //(env_ != nullptr) ? ElapsedNanos(reset) : 0U;
   }
 
  private:


### PR DESCRIPTION
This branch and PR has a proper fix and unit test for MergeHelper::FilterMerge().  Previous branch simply commented out all of the timing routines.  