### PR TITLE
BugFix:revert my hack that disabled StopWatchNano

### DIFF
--- a/util/stop_watch.h
+++ b/util/stop_watch.h
@@ -91,10 +91,10 @@ class StopWatchNano {
     }
   }
 
-  void Start() { start_ = 0; /*env_->NowNanos();*/ }
+  void Start() { start_ = env_->NowNanos(); }
 
   uint64_t ElapsedNanos(bool reset = false) {
-    auto now = 0; // env_->NowNanos();
+    auto now = env_->NowNanos();
     auto elapsed = now - start_;
     if (reset) {
       start_ = now;
@@ -103,7 +103,7 @@ class StopWatchNano {
   }
 
   uint64_t ElapsedNanosSafe(bool reset = false) {
-    return 0; //(env_ != nullptr) ? ElapsedNanos(reset) : 0U;
+    return (env_ != nullptr) ? ElapsedNanos(reset) : 0U;
   }
 
  private:


### PR DESCRIPTION
revert my hack that disabled StopWatchNano ... and caused build warnings relating to unused Env_ variable.

This was supposed to be part of previous PR, but obviously forgotten.  Pulled the file from stardog-develop-1.11 branch and resubmitted here.  Hopefully eliminating chance of typos.