### PR TITLE
Feature:  Add 5.x GetIntProperties() for table cache

### DIFF
--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -1688,6 +1688,44 @@ TEST_F(DBPropertiesTest, BlockCacheProperties) {
   ASSERT_EQ(0, value);
 }
 
+TEST_F(DBPropertiesTest, TableCacheProperties) {
+  Options options;
+  uint64_t value, new_value;
+
+  options.env = CurrentOptions().env;
+
+  // Block cache properties are not available if block cache is not used.
+  BlockBasedTableOptions table_options;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+  Reopen(options);
+
+  //
+  // test table_cache access is "live"
+  //  get default max_open_files
+  //
+  ASSERT_TRUE(
+      db_->GetIntProperty(DB::Properties::kTableCacheCapacity, &value));
+  new_value = value / 2;
+
+  std::unordered_map<std::string, std::string> new_options;
+  new_options.insert(std::pair<std::string, std::string>("max_open_files", std::to_string(new_value)));
+  ASSERT_OK(db_->SetDBOptions(new_options));
+  ASSERT_TRUE(
+      db_->GetIntProperty(DB::Properties::kTableCacheCapacity, &value));
+  // rocksdb does a -10 to number passed in
+  ASSERT_EQ(new_value - 10, value);
+
+  //
+  // create a new table to see if usage is "live"
+  //
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTableCacheUsage, &value));
+  ASSERT_OK(Put("foo", "v1"));
+  ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
+  ASSERT_TRUE(db_->GetIntProperty(DB::Properties::kTableCacheUsage, &new_value));
+  ASSERT_EQ(new_value, value + 1);
+
+}
+
 #endif  // ROCKSDB_LITE
 }  // namespace rocksdb
 

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -251,6 +251,8 @@ static const std::string estimate_oldest_key_time = "estimate-oldest-key-time";
 static const std::string block_cache_capacity = "block-cache-capacity";
 static const std::string block_cache_usage = "block-cache-usage";
 static const std::string block_cache_pinned_usage = "block-cache-pinned-usage";
+static const std::string tablecache_capacity = "table-cache-capacity";
+static const std::string tablecache_usage = "table-cache-usage";
 static const std::string options_statistics = "options-statistics";
 
 const std::string DB::Properties::kNumFilesAtLevelPrefix =
@@ -337,6 +339,10 @@ const std::string DB::Properties::kBlockCacheUsage =
     rocksdb_prefix + block_cache_usage;
 const std::string DB::Properties::kBlockCachePinnedUsage =
     rocksdb_prefix + block_cache_pinned_usage;
+const std::string DB::Properties::kTableCacheCapacity =
+    rocksdb_prefix + tablecache_capacity;
+const std::string DB::Properties::kTableCacheUsage =
+    rocksdb_prefix + tablecache_usage;
 const std::string DB::Properties::kOptionsStatistics =
     rocksdb_prefix + options_statistics;
 
@@ -471,6 +477,12 @@ const std::unordered_map<std::string, DBPropertyInfo>
           nullptr}},
         {DB::Properties::kBlockCachePinnedUsage,
          {false, nullptr, &InternalStats::HandleBlockCachePinnedUsage, nullptr,
+          nullptr}},
+        {DB::Properties::kTableCacheCapacity,
+         {false, nullptr, &InternalStats::HandleTableCacheCapacity, nullptr,
+          nullptr}},
+        {DB::Properties::kTableCacheUsage,
+         {false, nullptr, &InternalStats::HandleTableCacheUsage, nullptr,
           nullptr}},
         {DB::Properties::kOptionsStatistics,
          {false, nullptr, nullptr, nullptr,
@@ -938,6 +950,19 @@ bool InternalStats::HandleBlockCachePinnedUsage(uint64_t* value, DBImpl* /*db*/,
   *value = static_cast<uint64_t>(block_cache->GetPinnedUsage());
   return true;
 }
+
+bool InternalStats::HandleTableCacheCapacity(uint64_t* value, DBImpl* db,
+                                             Version* /*version*/) {
+  *value = static_cast<uint64_t>(db->table_cache_->GetCapacity());
+  return true;
+}
+
+bool InternalStats::HandleTableCacheUsage(uint64_t* value, DBImpl* db,
+                                          Version* /*version*/) {
+  *value = static_cast<uint64_t>(db->table_cache_->GetUsage());
+  return true;
+}
+
 
 void InternalStats::DumpDBStats(std::string* value) {
   char buf[1000];

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -544,6 +544,8 @@ class InternalStats {
   bool HandleBlockCacheUsage(uint64_t* value, DBImpl* db, Version* version);
   bool HandleBlockCachePinnedUsage(uint64_t* value, DBImpl* db,
                                    Version* version);
+  bool HandleTableCacheCapacity(uint64_t* value, DBImpl* db, Version* version);
+  bool HandleTableCacheUsage(uint64_t* value, DBImpl* db, Version* version);
   // Total number of background errors encountered. Every time a flush task
   // or compaction task fails, this counter is incremented. The failure can
   // be caused by any possible reason, including file system errors, out of

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -625,6 +625,13 @@ class DB {
     //      entries being pinned.
     static const std::string kBlockCachePinnedUsage;
 
+    //  "rocksdb.table-cache-capacity" - returns table cache capacity.
+    static const std::string kTableCacheCapacity;
+
+    //  "rocksdb.table-cache-usage" - returns the memory size for the entries
+    //      residing in table cache.
+    static const std::string kTableCacheUsage;
+
     // "rocksdb.options-statistics" - returns multi-line string
     //      of options.statistics
     static const std::string kOptionsStatistics;
@@ -684,6 +691,8 @@ class DB {
   //  "rocksdb.block-cache-capacity"
   //  "rocksdb.block-cache-usage"
   //  "rocksdb.block-cache-pinned-usage"
+  //  "rocksdb.table-cache-capacity"
+  //  "rocksdb.table-cache-usage"
   virtual bool GetIntProperty(ColumnFamilyHandle* column_family,
                               const Slice& property, uint64_t* value) = 0;
   virtual bool GetIntProperty(const Slice& property, uint64_t* value) {

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -26,9 +26,13 @@ class WriteBufferManager {
   // the memory allocated to the cache. It can be used even if _buffer_size = 0.
   explicit WriteBufferManager(size_t _buffer_size,
                               std::shared_ptr<Cache> cache = {});
+  // No copying allowed
+  WriteBufferManager(const WriteBufferManager&) = delete;
+  WriteBufferManager& operator=(const WriteBufferManager&) = delete;
+
   ~WriteBufferManager();
 
-  bool enabled() const { return buffer_size_ != 0; }
+  bool enabled() const { return buffer_size() > 0; }
 
   bool cost_to_cache() const { return cache_rep_ != nullptr; }
 
@@ -39,16 +43,23 @@ class WriteBufferManager {
   size_t mutable_memtable_memory_usage() const {
     return memory_active_.load(std::memory_order_relaxed);
   }
-  size_t buffer_size() const { return buffer_size_; }
+  size_t dummy_entries_in_cache_usage() const {
+    return dummy_size_.load(std::memory_order_relaxed);
+  }
+  size_t buffer_size() const {
+    return buffer_size_.load(std::memory_order_relaxed);
+  }
 
   // Should only be called from write thread
   bool ShouldFlush() const {
     if (enabled()) {
-      if (mutable_memtable_memory_usage() > mutable_limit_) {
+      if (mutable_memtable_memory_usage() >
+          mutable_limit_.load(std::memory_order_relaxed)) {
         return true;
       }
-      if (memory_usage() >= buffer_size_ &&
-          mutable_memtable_memory_usage() >= buffer_size_ / 2) {
+      size_t local_size = buffer_size();
+      if (memory_usage() >= local_size &&
+          mutable_memtable_memory_usage() >= local_size / 2) {
         // If the memory exceeds the buffer size, we trigger more aggressive
         // flush. But if already more than half memory is being flushed,
         // triggering more flush may not help. We will hold it instead.
@@ -84,23 +95,21 @@ class WriteBufferManager {
   }
 
   void SetBufferSize(size_t new_size) {
-    buffer_size_ = new_size;
+    buffer_size_.store(new_size, std::memory_order_relaxed);
+    mutable_limit_.store(new_size * 7 / 8, std::memory_order_relaxed);
   }
 
  private:
   std::atomic<size_t> buffer_size_;
-  const size_t mutable_limit_;
+  std::atomic<size_t> mutable_limit_;
   std::atomic<size_t> memory_used_;
   // Memory that hasn't been scheduled to free.
   std::atomic<size_t> memory_active_;
+  std::atomic<size_t> dummy_size_;
   struct CacheRep;
   std::unique_ptr<CacheRep> cache_rep_;
 
   void ReserveMemWithCache(size_t mem);
   void FreeMemWithCache(size_t mem);
-
-  // No copying allowed
-  WriteBufferManager(const WriteBufferManager&) = delete;
-  WriteBufferManager& operator=(const WriteBufferManager&) = delete;
 };
-}  // namespace rocksdb
+}  // namespace ROCKSDB_NAMESPACE

--- a/util/build_version.cc
+++ b/util/build_version.cc
@@ -1,4 +1,4 @@
 #include "build_version.h"
-const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:42f9f56c6fc201804d3905deb5f6337669578220";
-const char* rocksdb_build_git_date = "rocksdb_build_git_date:2020-04-22";
+const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:3e338d74139fa09b23f4850079c5bcb1b191d2c1";
+const char* rocksdb_build_git_date = "rocksdb_build_git_date:2021-02-24";
 const char* rocksdb_build_compile_date = __DATE__;


### PR DESCRIPTION
This PR contains new code already accepted by Facebook:

  https://github.com/facebook/rocksdb/pull/7993

And this PR updates previous code that contains updates per Facebook:

  https://github.com/facebook/rocksdb/pull/7961

7993 adds the ability to retrieve integer properties about rocksdb's table cache:  capacity and usage.  The usage value is now part of memory budget computations within starrocks/main/native/src/memory_configuration.cpp.

7961 updates SetBuffer() within WriteBufferManager object to update BOTH buffer_size_ and mutable_limit_.  mutable_limit_ was not updated in original code checked into Stardog's RocksDb.  Also made assignments and retrievals of buffer_size_ consistent with proper atomic variable usage.