### PR TITLE
BugFix: fix merge helper clock usage and rehack LoadTableHandlers

### DIFF
--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -414,7 +414,9 @@ CompactionFilter::Decision MergeHelper::FilterMerge(const Slice& user_key,
                                                        kValueTypeForSeek);
     }
   }
-  total_filter_time_ += filter_timer_.ElapsedNanosSafe();
+  if (stats_ != nullptr && ShouldReportDetailedTime(env_, stats_)) {
+    total_filter_time_ += filter_timer_.ElapsedNanosSafe();
+  }
   return ret;
 }
 


### PR DESCRIPTION
Two quick fixes:

- backport Facebook PR 7867 to manage unnecessary clock calls in FilterMerge().  Our original 5.x fix was lost during upgrade to 6.x

- previous hack to LoadTableHandlers() works fine in production but causes some check tests to fail.  Made another ugly hack while waiting for full fledged fix to be approved by Facebook.