### PR TITLE
adjust WriteStallNotification object to not depend upon pointer

### DIFF
--- a/db/job_context.h
+++ b/db/job_context.h
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include "db/log_writer.h"
 #include "db/column_family.h"
+#include "db/log_writer.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -34,7 +34,7 @@ struct SuperVersionContext {
       new_superversion;  // if nullptr no new superversion
 
   explicit SuperVersionContext(bool create_superversion = false)
-    : new_superversion(create_superversion ? new SuperVersion() : nullptr) {}
+      : new_superversion(create_superversion ? new SuperVersion() : nullptr) {}
 
   explicit SuperVersionContext(SuperVersionContext&& other)
       : superversions_to_free(std::move(other.superversions_to_free)),
@@ -50,16 +50,16 @@ struct SuperVersionContext {
 
   inline bool HaveSomethingToDelete() const {
 #ifndef ROCKSDB_DISABLE_STALL_NOTIFICATION
-    return !superversions_to_free.empty() ||
-           !write_stall_notifications.empty();
+    return !superversions_to_free.empty() || !write_stall_notifications.empty();
 #else
     return !superversions_to_free.empty();
 #endif
   }
 
-  void PushWriteStallNotification(
-      WriteStallCondition old_cond, WriteStallCondition new_cond,
-      const std::string& name, const ImmutableCFOptions* ioptions) {
+  void PushWriteStallNotification(WriteStallCondition old_cond,
+                                  WriteStallCondition new_cond,
+                                  const std::string& name,
+                                  const ImmutableCFOptions* ioptions) {
 #if !defined(ROCKSDB_LITE) && !defined(ROCKSDB_DISABLE_STALL_NOTIFICATION)
     WriteStallNotification notif;
     notif.write_stall_info.cf_name = name;
@@ -72,7 +72,8 @@ struct SuperVersionContext {
     (void)new_cond;
     (void)name;
     (void)ioptions;
-#endif  // !defined(ROCKSDB_LITE) && !defined(ROCKSDB_DISABLE_STALL_NOTIFICATION)
+#endif  // !defined(ROCKSDB_LITE) &&
+        // !defined(ROCKSDB_DISABLE_STALL_NOTIFICATION)
   }
 
   void Clean() {
@@ -126,8 +127,7 @@ struct JobContext {
     CandidateFileInfo(std::string name, std::string path)
         : file_name(std::move(name)), file_path(std::move(path)) {}
     bool operator==(const CandidateFileInfo& other) const {
-      return file_name == other.file_name &&
-             file_path == other.file_path;
+      return file_name == other.file_name && file_path == other.file_path;
     }
   };
 

--- a/db/job_context.h
+++ b/db/job_context.h
@@ -23,7 +23,7 @@ struct SuperVersion;
 struct SuperVersionContext {
   struct WriteStallNotification {
     WriteStallInfo write_stall_info;
-    const ImmutableCFOptions* immutable_cf_options;
+    std::vector<std::shared_ptr<EventListener>> immutable_options_listeners;
   };
 
   autovector<SuperVersion*> superversions_to_free;
@@ -65,7 +65,7 @@ struct SuperVersionContext {
     notif.write_stall_info.cf_name = name;
     notif.write_stall_info.condition.prev = old_cond;
     notif.write_stall_info.condition.cur = new_cond;
-    notif.immutable_cf_options = ioptions;
+    notif.immutable_options_listeners = ioptions->listeners;
     write_stall_notifications.push_back(notif);
 #else
     (void)old_cond;
@@ -79,7 +79,7 @@ struct SuperVersionContext {
 #if !defined(ROCKSDB_LITE) && !defined(ROCKSDB_DISABLE_STALL_NOTIFICATION)
     // notify listeners on changed write stall conditions
     for (auto& notif : write_stall_notifications) {
-      for (auto& listener : notif.immutable_cf_options->listeners) {
+      for (auto& listener : notif.immutable_options_listeners) {
         listener->OnStallConditionsChanged(notif.write_stall_info);
       }
     }

--- a/monitoring/iostats_context.cc
+++ b/monitoring/iostats_context.cc
@@ -20,9 +20,7 @@ __thread IOStatsContext iostats_context;
     "No thread-local support. Disable iostats context with -DNIOSTATS_CONTEXT."
 #endif
 
-IOStatsContext* get_iostats_context() {
-  return &iostats_context;
-}
+IOStatsContext* get_iostats_context() { return &iostats_context; }
 
 void IOStatsContext::Reset() {
 #ifndef NIOSTATS_CONTEXT

--- a/monitoring/perf_context.cc
+++ b/monitoring/perf_context.cc
@@ -23,12 +23,11 @@ thread_local PerfContext perf_context;
 #error "No thread-local support. Disable perf context with -DNPERF_CONTEXT."
 #endif
 
-PerfContext* get_perf_context() {
-  return &perf_context;
-}
+PerfContext* get_perf_context() { return &perf_context; }
 
 PerfContext::~PerfContext() {
-#if !defined(NPERF_CONTEXT) && defined(ROCKSDB_SUPPORT_THREAD_LOCAL) && !defined(OS_SOLARIS)
+#if !defined(NPERF_CONTEXT) && defined(ROCKSDB_SUPPORT_THREAD_LOCAL) && \
+    !defined(OS_SOLARIS)
   ClearPerLevelPerfContext();
 #endif
 }
@@ -422,15 +421,14 @@ void PerfContext::Reset() {
     ss << #counter << " = " << counter << ", ";  \
   }
 
-#define PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(counter)         \
-  if (per_level_perf_context_enabled && \
-      level_to_perf_context) {                                    \
-    ss << #counter << " = ";                                      \
-    for (auto& kv : *level_to_perf_context) {                     \
-      if (!exclude_zero_counters || (kv.second.counter > 0)) {    \
-        ss << kv.second.counter << "@level" << kv.first << ", ";  \
-      }                                                           \
-    }                                                             \
+#define PERF_CONTEXT_BY_LEVEL_OUTPUT_ONE_COUNTER(counter)        \
+  if (per_level_perf_context_enabled && level_to_perf_context) { \
+    ss << #counter << " = ";                                     \
+    for (auto& kv : *level_to_perf_context) {                    \
+      if (!exclude_zero_counters || (kv.second.counter > 0)) {   \
+        ss << kv.second.counter << "@level" << kv.first << ", "; \
+      }                                                          \
+    }                                                            \
   }
 
 void PerfContextByLevel::Reset() {
@@ -546,11 +544,11 @@ void PerfContext::EnablePerLevelPerfContext() {
   per_level_perf_context_enabled = true;
 }
 
-void PerfContext::DisablePerLevelPerfContext(){
+void PerfContext::DisablePerLevelPerfContext() {
   per_level_perf_context_enabled = false;
 }
 
-void PerfContext::ClearPerLevelPerfContext(){
+void PerfContext::ClearPerLevelPerfContext() {
   if (level_to_perf_context != nullptr) {
     level_to_perf_context->clear();
     delete level_to_perf_context;


### PR DESCRIPTION
NOTE:  perf_context.cc and iostats_context.cc only have white space changes to get the "buck targets" test to pass.

We encountered a race condition where a column family's immutable options object could be destructed before a background compaction finished cleaning up.  The solution was to copy the listeners vector from the immutable object instead of hoping the options and its vector were still around.