### PR TITLE
PLAT-6480: add headers that are no longer implicitly added

### DIFF
--- a/db/compaction/compaction_iteration_stats.h
+++ b/db/compaction/compaction_iteration_stats.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "rocksdb/rocksdb_namespace.h"
 
 struct CompactionIterationStats {

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -8,6 +8,7 @@
 #pragma once
 #ifndef ROCKSDB_LITE
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "rocksdb/status.h"

--- a/table/block_based/data_block_hash_index.h
+++ b/table/block_based/data_block_hash_index.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/third-party/folly/folly/synchronization/detail/ProxyLockable-inl.h
+++ b/third-party/folly/folly/synchronization/detail/ProxyLockable-inl.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <system_error>
 #include <utility>
 
 namespace folly {

--- a/util/string_util.h
+++ b/util/string_util.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
gcc headers no longer imply headers such as <cstdint> and <system_error> and therefore break the rocksdb build.  5 files updated as needed.  This is still needed for Stardog's Windows build.