### PR TITLE
PLAT-800: used EXFOs load_to_stardog test to validate new skiplist settings

### DIFF
--- a/memtable/inlineskiplist.h
+++ b/memtable/inlineskiplist.h
@@ -72,8 +72,8 @@ class InlineSkipList {
   // in the allocator must remain allocated for the lifetime of the
   // skiplist object.
   explicit InlineSkipList(Comparator cmp, Allocator* allocator,
-                          int32_t max_height = 12,
-                          int32_t branching_factor = 4);
+                          int32_t max_height = 24,
+                          int32_t branching_factor = 2);
   // No copying allowed
   InlineSkipList(const InlineSkipList&) = delete;
   InlineSkipList& operator=(const InlineSkipList&) = delete;

--- a/memtable/skiplist.h
+++ b/memtable/skiplist.h
@@ -50,7 +50,7 @@ class SkipList {
   // and will allocate memory using "*allocator".  Objects allocated in the
   // allocator must remain allocated for the lifetime of the skiplist object.
   explicit SkipList(Comparator cmp, Allocator* allocator,
-                    int32_t max_height = 12, int32_t branching_factor = 4);
+                    int32_t max_height = 24, int32_t branching_factor = 2);
   // No copying allowed
   SkipList(const SkipList&) = delete;
   void operator=(const SkipList&) = delete;


### PR DESCRIPTION
Flamegraph and timing tests demonstrated that skiplist height was too low.  Trial and error measurement of branch factor yielded even better results.  Following table shows height/branch factor settings and two sequential timings of EXFOs load_to_stardog:

- 12/4  6m02 6m17
- 17/4  4m49 4m33
- 24/4  4m38 4m41
- 24/6  4m50 4m50
- 20/4  4m32 4m47
- 24/3  4m30 4m28
- 24/2  4m23 4m27