### PR TITLE
Mv 6.20 mem management

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -4290,6 +4290,10 @@ Status DBImpl::WriteOptionsFile(bool need_mutex_lock,
 
   if (s.ok()) {
     s = RenameTempFileToOptionsFile(file_name);
+  } else {
+    // do not accumulate failed files
+    //  (could be hundreds with bad options code)
+    (void)env_->DeleteFile(file_name).ok();
   }
   // restore lock
   if (!need_mutex_lock) {

--- a/db/external_sst_file_ingestion_job.cc
+++ b/db/external_sst_file_ingestion_job.cc
@@ -497,7 +497,8 @@ void ExternalSstFileIngestionJob::UpdateStats() {
         "(global_seqno=%" PRIu64 ")\n",
         f.external_file_path.c_str(), f.picked_level,
         f.internal_file_path.c_str(), f.assigned_seqno);
-    stream << "file" << f.internal_file_path << "level" << f.picked_level;
+    stream << "file" << f.internal_file_path << "level" << f.picked_level
+           << "file_size" << f.fd.GetFileSize();
   }
   stream.EndArray();
 

--- a/db/version_builder.cc
+++ b/db/version_builder.cc
@@ -1142,6 +1142,10 @@ class VersionBuilder::Rep {
       size_t max_file_size_for_l0_meta_pin) {
     assert(table_cache_ != nullptr);
 
+    if (kFilePreloadDisabled == ioptions_->file_preload) {
+      return Status::OK();
+    }
+
     size_t table_cache_capacity = table_cache_->get_cache()->GetCapacity();
     bool always_load = (table_cache_capacity == TableCache::kInfiniteCapacity);
     size_t max_load = std::numeric_limits<size_t>::max();

--- a/db/version_edit_handler.cc
+++ b/db/version_edit_handler.cc
@@ -534,7 +534,9 @@ Status VersionEditHandler::MaybeCreateVersion(const VersionEdit& /*edit*/,
       // Install new version
       v->PrepareAppend(
           *cfd->GetLatestMutableCFOptions(),
-          !(version_set_->db_options_->skip_stats_update_on_db_open));
+          !(version_set_->db_options_->skip_stats_update_on_db_open ||
+            kFilePreloadDisabled == cfd->ioptions()->file_preload));
+
       version_set_->AppendVersion(cfd, v);
     } else {
       delete v;
@@ -808,7 +810,8 @@ Status VersionEditHandlerPointInTime::MaybeCreateVersion(
     if (s.ok()) {
       version->PrepareAppend(
           *cfd->GetLatestMutableCFOptions(),
-          !version_set_->db_options_->skip_stats_update_on_db_open);
+          !(version_set_->db_options_->skip_stats_update_on_db_open ||
+            kFilePreloadDisabled == cfd->ioptions()->file_preload));
       auto v_iter = versions_.find(cfd->GetID());
       if (v_iter != versions_.end()) {
         delete v_iter->second;

--- a/include/rocksdb/advanced_options.h
+++ b/include/rocksdb/advanced_options.h
@@ -56,6 +56,25 @@ enum CompactionPri : char {
   kMinOverlappingRatio = 0x3,
 };
 
+// RocksDB uses the first 25% of num_open_files for precaching during
+//  start-up and after compactions.  The files precached in this fashion
+//  provide faster access.  However, these files are also never released.
+//  Scenarios that have large bloom filters not cached or scenarios where
+//  user is manually lowering the num_open_files at runtime might want
+//  to disable this behavior.
+enum FilePreload : char {
+  // RocksDB uses the first 25% of num_open_files for precaching during
+  //  start-up and after compactions.  The files precached in this fashion
+  //  provide faster access.  However, these files are also never released.
+  kFilePreloadWithPinning = 0x0,
+  // RocksDB uses the first 25% of num_open_files for precaching during
+  //  start-up and after compactions.  No pinning within cache, so access
+  //  has one additional layer of indirection.  But cache space can free.
+  kFilePreloadWithoutPinning = 0x1,
+  // RocksDB does not open existing table files during start-up.
+  kFilePreloadDisabled = 0x2,
+};
+
 struct CompactionOptionsFIFO {
   // once the total sum of table files reaches this, we will delete the oldest
   // table file
@@ -773,6 +792,13 @@ struct AdvancedColumnFamilyOptions {
   // Options::DisableExtraChecks().
   // Default: true
   bool force_consistency_checks = true;
+
+  // RocksDB can preload and optionally pin table files within the table
+  //  cache at start-up and after compactions.  The files precached in this
+  //  fashion provide faster access.  However, these files are also never
+  //  released from the table cache.
+  // Default: kFilePreloadWithPinning
+  FilePreload file_preload = kFilePreloadWithPinning;
 
   // Measure IO stats in compactions and flushes, if true.
   //

--- a/include/rocksdb/utilities/options_type.h
+++ b/include/rocksdb/utilities/options_type.h
@@ -57,6 +57,7 @@ enum class OptionType {
   kEncodedString,
   kTemperature,
   kArray,
+  kFilePreload,
   kUnknown,
 };
 

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -539,6 +539,10 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct ImmutableCFOptions, force_consistency_checks),
           OptionType::kBoolean, OptionVerificationType::kNormal,
           OptionTypeFlags::kNone}},
+        {"file_preload",
+         {offsetof(struct ImmutableCFOptions, file_preload),
+          OptionType::kFilePreload, OptionVerificationType::kNormal,
+          OptionTypeFlags::kNone}},
         // Need to keep this around to be able to read old OPTIONS files.
         {"max_mem_compaction_level",
          {0, OptionType::kInt, OptionVerificationType::kDeprecated,
@@ -862,6 +866,7 @@ ImmutableCFOptions::ImmutableCFOptions(const ColumnFamilyOptions& cf_options)
       num_levels(cf_options.num_levels),
       optimize_filters_for_hits(cf_options.optimize_filters_for_hits),
       force_consistency_checks(cf_options.force_consistency_checks),
+      file_preload(cf_options.file_preload),
       memtable_insert_with_hint_prefix_extractor(
           cf_options.memtable_insert_with_hint_prefix_extractor),
       cf_paths(cf_options.cf_paths),

--- a/options/cf_options.h
+++ b/options/cf_options.h
@@ -70,6 +70,8 @@ struct ImmutableCFOptions {
 
   bool force_consistency_checks;
 
+  FilePreload file_preload;
+
   std::shared_ptr<const SliceTransform>
       memtable_insert_with_hint_prefix_extractor;
 

--- a/options/options.cc
+++ b/options/options.cc
@@ -87,6 +87,7 @@ AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions(const Options& options)
       optimize_filters_for_hits(options.optimize_filters_for_hits),
       paranoid_file_checks(options.paranoid_file_checks),
       force_consistency_checks(options.force_consistency_checks),
+      file_preload(options.file_preload),
       report_bg_io_stats(options.report_bg_io_stats),
       ttl(options.ttl),
       periodic_compaction_seconds(options.periodic_compaction_seconds),
@@ -388,6 +389,8 @@ void ColumnFamilyOptions::Dump(Logger* log) const {
                      paranoid_file_checks);
     ROCKS_LOG_HEADER(log, "               Options.force_consistency_checks: %d",
                      force_consistency_checks);
+    ROCKS_LOG_HEADER(log, "               Options.file_preload: %d",
+                     file_preload);
     ROCKS_LOG_HEADER(log, "               Options.report_bg_io_stats: %d",
                      report_bg_io_stats);
     ROCKS_LOG_HEADER(log, "                              Options.ttl: %" PRIu64,

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -326,11 +326,6 @@ std::map<CompactionStopStyle, std::string>
         {kCompactionStopStyleSimilarSize, "kCompactionStopStyleSimilarSize"},
         {kCompactionStopStyleTotalSize, "kCompactionStopStyleTotalSize"}};
 
-std::map<FilePreload, std::string> OptionsHelper::file_preload_to_string = {
-    {FilePreload::kFilePreloadWithPinning, "kFilePreloadWithPinning"},
-    {FilePreload::kFilePreloadWithoutPinning, "kFilePreloadWithoutPinning"},
-    {FilePreload::kFilePreloadDisabled, "kFilePreloadDisabled"}};
-
 std::map<Temperature, std::string> OptionsHelper::temperature_to_string = {
     {Temperature::kUnknown, "kUnknown"},
     {Temperature::kHot, "kHot"},
@@ -848,6 +843,11 @@ std::unordered_map<std::string, CompactionStopStyle>
     OptionsHelper::compaction_stop_style_string_map = {
         {"kCompactionStopStyleSimilarSize", kCompactionStopStyleSimilarSize},
         {"kCompactionStopStyleTotalSize", kCompactionStopStyleTotalSize}};
+
+std::map<FilePreload, std::string> OptionsHelper::file_preload_to_string = {
+    {FilePreload::kFilePreloadWithPinning, "kFilePreloadWithPinning"},
+    {FilePreload::kFilePreloadWithoutPinning, "kFilePreloadWithoutPinning"},
+    {FilePreload::kFilePreloadDisabled, "kFilePreloadDisabled"}};
 
 std::unordered_map<std::string, FilePreload>
     OptionsHelper::file_preload_string_map = {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -297,6 +297,7 @@ void UpdateColumnFamilyOptions(const ImmutableCFOptions& ioptions,
   cf_opts->num_levels = ioptions.num_levels;
   cf_opts->optimize_filters_for_hits = ioptions.optimize_filters_for_hits;
   cf_opts->force_consistency_checks = ioptions.force_consistency_checks;
+  cf_opts->file_preload = ioptions.file_preload;
   cf_opts->memtable_insert_with_hint_prefix_extractor =
       ioptions.memtable_insert_with_hint_prefix_extractor;
   cf_opts->cf_paths = ioptions.cf_paths;
@@ -324,6 +325,11 @@ std::map<CompactionStopStyle, std::string>
     OptionsHelper::compaction_stop_style_to_string = {
         {kCompactionStopStyleSimilarSize, "kCompactionStopStyleSimilarSize"},
         {kCompactionStopStyleTotalSize, "kCompactionStopStyleTotalSize"}};
+
+std::map<FilePreload, std::string> OptionsHelper::file_preload_to_string = {
+    {FilePreload::kFilePreloadWithPinning, "kFilePreloadWithPinning"},
+    {FilePreload::kFilePreloadWithoutPinning, "kFilePreloadWithoutPinning"},
+    {FilePreload::kFilePreloadDisabled, "kFilePreloadDisabled"}};
 
 std::map<Temperature, std::string> OptionsHelper::temperature_to_string = {
     {Temperature::kUnknown, "kUnknown"},
@@ -433,6 +439,10 @@ static bool ParseOptionHelper(void* opt_address, const OptionType& opt_type,
       return ParseEnum<CompressionType>(
           compression_type_string_map, value,
           static_cast<CompressionType*>(opt_address));
+    case OptionType::kFilePreload:
+      return ParseEnum<FilePreload>(
+          file_preload_string_map, value,
+          reinterpret_cast<FilePreload*>(opt_address));
     case OptionType::kChecksumType:
       return ParseEnum<ChecksumType>(checksum_type_string_map, value,
                                      static_cast<ChecksumType*>(opt_address));
@@ -522,6 +532,10 @@ bool SerializeSingleOptionHelper(const void* opt_address,
           compression_type_string_map,
           *(static_cast<const CompressionType*>(opt_address)), value);
       break;
+    case OptionType::kFilePreload:
+      return SerializeEnum<FilePreload>(
+          file_preload_string_map,
+          *(reinterpret_cast<const FilePreload*>(opt_address)), value);
     case OptionType::kChecksumType:
       return SerializeEnum<ChecksumType>(
           checksum_type_string_map,
@@ -834,6 +848,12 @@ std::unordered_map<std::string, CompactionStopStyle>
     OptionsHelper::compaction_stop_style_string_map = {
         {"kCompactionStopStyleSimilarSize", kCompactionStopStyleSimilarSize},
         {"kCompactionStopStyleTotalSize", kCompactionStopStyleTotalSize}};
+
+std::unordered_map<std::string, FilePreload>
+    OptionsHelper::file_preload_string_map = {
+        {"kFilePreloadWithPinning", FilePreload::kFilePreloadWithPinning},
+        {"kFilePreloadWithoutPinning", FilePreload::kFilePreloadWithoutPinning},
+        {"kFilePreloadDisabled", FilePreload::kFilePreloadDisabled}};
 
 std::unordered_map<std::string, Temperature>
     OptionsHelper::temperature_string_map = {
@@ -1206,6 +1226,8 @@ static bool AreOptionsEqual(OptionType type, const void* this_offset,
       return IsOptionEqual<CompactionPri>(this_offset, that_offset);
     case OptionType::kCompressionType:
       return IsOptionEqual<CompressionType>(this_offset, that_offset);
+    case OptionType::kFilePreload:
+      return IsOptionEqual<FilePreload>(this_offset, that_offset);
     case OptionType::kChecksumType:
       return IsOptionEqual<ChecksumType>(this_offset, that_offset);
     case OptionType::kEncodingType:

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -102,7 +102,6 @@ static auto& compaction_style_to_string =
 static auto& compaction_pri_to_string = OptionsHelper::compaction_pri_to_string;
 static auto& compaction_stop_style_to_string =
     OptionsHelper::compaction_stop_style_to_string;
-static auto& file_preload_string_map = OptionsHelper::file_preload_string_map;
 static auto& temperature_to_string = OptionsHelper::temperature_to_string;
 static auto& checksum_type_string_map = OptionsHelper::checksum_type_string_map;
 #ifndef ROCKSDB_LITE
@@ -115,6 +114,7 @@ static auto& compaction_style_string_map =
     OptionsHelper::compaction_style_string_map;
 static auto& compaction_pri_string_map =
     OptionsHelper::compaction_pri_string_map;
+static auto& file_preload_string_map = OptionsHelper::file_preload_string_map;
 static auto& temperature_string_map = OptionsHelper::temperature_string_map;
 #endif  // !ROCKSDB_LITE
 

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -90,6 +90,8 @@ struct OptionsHelper {
       compaction_style_string_map;
   static std::unordered_map<std::string, CompactionPri>
       compaction_pri_string_map;
+  static std::map<FilePreload, std::string> file_preload_to_string;
+  static std::unordered_map<std::string, FilePreload> file_preload_string_map;
   static std::unordered_map<std::string, Temperature> temperature_string_map;
 #endif  // !ROCKSDB_LITE
 };
@@ -100,6 +102,7 @@ static auto& compaction_style_to_string =
 static auto& compaction_pri_to_string = OptionsHelper::compaction_pri_to_string;
 static auto& compaction_stop_style_to_string =
     OptionsHelper::compaction_stop_style_to_string;
+static auto& file_preload_string_map = OptionsHelper::file_preload_string_map;
 static auto& temperature_to_string = OptionsHelper::temperature_to_string;
 static auto& checksum_type_string_map = OptionsHelper::checksum_type_string_map;
 #ifndef ROCKSDB_LITE

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -518,6 +518,7 @@ TEST_F(OptionsSettableTest, ColumnFamilyOptionsAllFieldsSettable) {
       "blob_compression_type=kBZip2Compression;"
       "enable_blob_garbage_collection=true;"
       "blob_garbage_collection_age_cutoff=0.5;"
+      "file_preload=kFilePreloadWithPinning;"
       "blob_garbage_collection_force_threshold=0.75;"
       "blob_compaction_readahead_size=262144;"
       "bottommost_temperature=kWarm;"


### PR DESCRIPTION
This is reapplication of https://github.com/stardog-union/rocksdb/pull/33 (and a couple of related cleanup PRs).  PR #33 was applied to 6.20.3.  This is applying same to 7.3.1 with new adjustments to column family options copy constructor.

The change to sst ingest logging is solely to add data for after the fact performance analysis.