### PR TITLE
extend when single memtable flushes should occur

### DIFF
--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1989,10 +1989,8 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     }
   }
 
-  if (flush_reason == FlushReason::kManualCompaction ||
-      flush_reason == FlushReason::kManualFlush) {
-    cfd->imm()->BeginManualOperation();
-  }
+  cfd->imm()->BeginManualOperation(flush_reason);
+
   autovector<FlushRequest> flush_reqs;
   autovector<uint64_t> memtable_ids_to_wait;
   {
@@ -2111,10 +2109,9 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
       tmp_cfd->UnrefAndTryDelete();
     }
   }
-  if (flush_reason == FlushReason::kManualCompaction ||
-      flush_reason == FlushReason::kManualFlush) {
-    cfd->imm()->CompleteManualOperation();
-  }
+
+  cfd->imm()->CompleteManualOperation(flush_reason);
+
   TEST_SYNC_POINT("DBImpl::FlushMemTable:FlushMemTableFinished");
   return s;
 }

--- a/db/memtable_list.h
+++ b/db/memtable_list.h
@@ -20,6 +20,7 @@
 #include "monitoring/instrumented_mutex.h"
 #include "rocksdb/db.h"
 #include "rocksdb/iterator.h"
+#include "rocksdb/listener.h"
 #include "rocksdb/options.h"
 #include "rocksdb/types.h"
 #include "util/autovector.h"
@@ -391,11 +392,17 @@ class MemTableList {
   void RemoveOldMemTables(uint64_t log_number,
                           autovector<MemTable*>* to_delete);
 
-  void BeginManualOperation() { ++active_manuals_; };
+  void BeginManualOperation(FlushReason flush_reason) {
+    if (NeedsSingleMemFlush(flush_reason)) {
+      ++active_manuals_;
+    } // if
+  };
 
-  void CompleteManualOperation() {
+  void CompleteManualOperation(FlushReason flush_reason) {
     assert(active_manuals_ >= 1);
-    --active_manuals_;
+    if (NeedsSingleMemFlush(flush_reason)) {
+      --active_manuals_;
+    } // if
   };
 
  private:
@@ -413,6 +420,22 @@ class MemTableList {
 
   // DB mutex held
   void InstallNewVersion();
+
+  bool NeedsSingleMemFlush(FlushReason flush_reason) {
+    bool ret_flag{false};
+
+    ret_flag = FlushReason::kGetLiveFiles == flush_reason
+               || FlushReason::kShutDown == flush_reason
+               || FlushReason::kExternalFileIngestion == flush_reason
+               || FlushReason::kManualCompaction == flush_reason
+               || FlushReason::kDeleteFiles == flush_reason
+               || FlushReason::kManualFlush == flush_reason
+               || FlushReason::kErrorRecovery == flush_reason
+               || FlushReason::kErrorRecoveryRetryFlush == flush_reason
+               || FlushReason::kWalFull == flush_reason;
+
+    return ret_flag;
+  }
 
   // DB mutex held
   // Called after writing to MANIFEST


### PR DESCRIPTION
customer with simultaneous Put() and sst_file_writer write paths hit the deadlock about min_write_buffer_number_to_merge being greater than one (we prefer two).